### PR TITLE
Use fileSystemRepresentation for POSIX APIs

### DIFF
--- a/ui/StoryMainViewController.m
+++ b/ui/StoryMainViewController.m
@@ -1093,17 +1093,17 @@ static void setColorTable(RichTextView *v) {
         
         NSArray *array = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, true);
         docPath = [array[0] copy];
-        chdir([docPath UTF8String]);
+        chdir([docPath fileSystemRepresentation]);
         
         storyGamePath = [docPath stringByAppendingPathComponent: @kFrotzGameDir];
         storyTopSavePath = [docPath stringByAppendingPathComponent: @kFrotzSaveDir];
         
         
         if (![fileMgr fileExistsAtPath: storyGamePath]) {
-            [fileMgr createDirectoryAtPath: storyGamePath attributes: nil];
+            [fileMgr createDirectoryAtPath: storyGamePath attributes: [NSDictionary dictionary]];
         }
         if (![fileMgr fileExistsAtPath: storyTopSavePath]) {
-            [fileMgr createDirectoryAtPath: storyTopSavePath attributes: nil];
+            [fileMgr createDirectoryAtPath: storyTopSavePath attributes: [NSDictionary dictionary]];
         }
         
         NSString *resourcePath = [[NSBundle mainBundle] resourcePath];
@@ -1115,9 +1115,9 @@ static void setColorTable(RichTextView *v) {
         storySIPSavePath= [storyTopSavePath stringByAppendingPathComponent: @kFrotzOldAutoSaveFile];
         activeStoryPath = [storyTopSavePath stringByAppendingPathComponent: @kFrotzAutoSaveActiveFile];
         
-        strcpy(SAVE_PATH, [storyTopSavePath UTF8String]);
+        strcpy(SAVE_PATH, [storyTopSavePath fileSystemRepresentation]);
         
-        strcpy(AUTOSAVE_FILE,  [storySIPSavePath UTF8String]);  // used by interpreter from z_save
+        strcpy(AUTOSAVE_FILE,  [storySIPSavePath fileSystemRepresentation]);  // used by interpreter from z_save
         
         m_currentStory = [NSMutableString stringWithString: @""];
         
@@ -2533,7 +2533,7 @@ static UIImage *GlkGetImageCallback(int imageNum) {
             [self.navigationController setNavigationBarHidden:m_landscape ? YES:NO animated:YES];
     }
     if (file)
-        strcpy(iosif_filename, [file UTF8String]);
+        strcpy(iosif_filename, [file fileSystemRepresentation]);
     else
         *iosif_filename = '\0';
     [self activateKeyboard];
@@ -2732,7 +2732,7 @@ static UIImage *GlkGetImageCallback(int imageNum) {
     }
     if (storySavePath) {
         storySIPSavePath= [storySavePath stringByAppendingPathComponent: @kFrotzAutoSaveFile];
-        strcpy(AUTOSAVE_FILE,  [storySIPSavePath UTF8String]);  // used by interpreter from z_save
+        strcpy(AUTOSAVE_FILE,  [storySIPSavePath fileSystemRepresentation]);  // used by interpreter from z_save
     }
 }
 
@@ -2767,8 +2767,8 @@ static UIImage *GlkGetImageCallback(int imageNum) {
     if (m_currentStory) {
         storySavePath = [storyTopSavePath stringByAppendingPathComponent: [self saveSubFolderForStory: m_currentStory]];
         if (![fileMgr fileExistsAtPath: storySavePath])
-            [fileMgr createDirectoryAtPath: storySavePath attributes: nil];
-    	strcpy(SAVE_PATH, [storySavePath UTF8String]);
+            [fileMgr createDirectoryAtPath: storySavePath attributes: [NSDictionary dictionary]];
+    	strcpy(SAVE_PATH, [storySavePath fileSystemRepresentation]);
         
         if (![fileMgr fileExistsAtPath: storySIPPathOld]) {
             [self updateAutosavePaths];
@@ -3832,7 +3832,7 @@ static void setScreenDims(char *storyNameBuf) {
                 NSString *savedScriptname = dict[@"scriptname"];
                 if (savedScriptname) {
                     savedScriptname = [self relativePathToAppAbsolutePath: savedScriptname];
-                    iosif_start_script((char*)[savedScriptname UTF8String]);
+                    iosif_start_script((char*)[savedScriptname fileSystemRepresentation]);
                 } else
                     iosif_stop_script();
                 

--- a/ui/main.m
+++ b/ui/main.m
@@ -8,9 +8,9 @@ int main(int argc, char **argv)
 
     @autoreleasepool {
 
-        NSString* resources = [[[NSBundle mainBundle] resourcePath] stringByAppendingString:@"/locale"];
+        NSString* resources = [[[NSBundle mainBundle] resourcePath] stringByAppendingPathComponent:@"locale"];
         static char path_locale[1024];
-        strcpy(path_locale, [resources cStringUsingEncoding:NSASCIIStringEncoding]);
+        strcpy(path_locale, [resources fileSystemRepresentation]);
         setenv("PATH_LOCALE", path_locale, 1);
         setlocale(LC_CTYPE, "en_US.UTF-8");
 

--- a/ui/ui_utils.m
+++ b/ui/ui_utils.m
@@ -386,7 +386,7 @@ BOOL readGLULheaderFromUlxOrBlorb(const char *filename, char *glulHeader) {
 
 
 BOOL metaDataFromBlorb(NSString *blorbFile, NSString **title, NSString **author, NSString **description, NSString **tuid) {
-    const char *filename = [blorbFile UTF8String];
+    const char *filename = [blorbFile fileSystemRepresentation];
     BOOL found = NO;
     FILE *fp;
     if ((fp = os_path_open(filename, "rb")) == NULL)
@@ -497,7 +497,7 @@ BOOL metaDataFromBlorb(NSString *blorbFile, NSString **title, NSString **author,
 }
 
 NSData *imageDataFromBlorb(NSString *blorbFile) {
-    const char *filename = [blorbFile UTF8String];
+    const char *filename = [blorbFile fileSystemRepresentation];
     NSData *data = nil;
     FILE *fp;
     if ((fp = os_path_open(filename, "rb")) == NULL)


### PR DESCRIPTION
Using `-[NSString UTF8String]` to pass to POSIX APIs like `fopen` isn't recommended, at least not on OS X, as the ordering of the UTF-16 code pages (used in HFS+) may be slightly different.

I don't know how this relates to iOS, though.