### PR TITLE
Modernization, take 2:

### DIFF
--- a/ui/AboutFrotz.h
+++ b/ui/AboutFrotz.h
@@ -9,7 +9,6 @@
 #import <UIKit/UIKit.h>
 #import "FrotzCommonWebView.h"
 
-@interface AboutFrotz : FrotzCommonWebViewController {
-}
+@interface AboutFrotz : FrotzCommonWebViewController
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 @end

--- a/ui/BookmarkListController.h
+++ b/ui/BookmarkListController.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@protocol BookmarkDelegate
+@protocol BookmarkDelegate <NSObject>
 -(void)enterURL:(NSString*)url;
 -(NSString*)currentURL;
 -(NSString*)currentURLTitle;
@@ -21,7 +21,7 @@
 @interface BookmarkListController : UITableViewController {
     NSMutableArray *m_sites;
     NSMutableArray *m_titles;
-    id<BookmarkDelegate> m_delegate;
+    id<BookmarkDelegate> __weak m_delegate;
     UITableView *m_tableView;
 }
 @property (nonatomic, weak) id<BookmarkDelegate> delegate;

--- a/ui/BookmarkListController.m
+++ b/ui/BookmarkListController.m
@@ -9,14 +9,7 @@
 #import "BookmarkListController.h"
 
 @implementation BookmarkListController
-
--(void)setDelegate:(id<BookmarkDelegate>)del {
-    m_delegate = del;
-}
-
--(id<BookmarkDelegate>)delegate {
-    return m_delegate;
-}
+@synthesize delegate = m_delegate;
 
 - (instancetype)initWithStyle:(UITableViewStyle)style {
     if ((self = [super initWithStyle:style])) {

--- a/ui/ColorPicker.h
+++ b/ui/ColorPicker.h
@@ -19,14 +19,13 @@
     CGFloat m_hue;
     CGFloat m_saturation;
     CGFloat m_value;
-    id<ColorPickerDelegate> m_delegate;
+    id<ColorPickerDelegate> __weak m_delegate;
     CGColorSpaceRef m_colorSpace;
 
     UIColor *m_textColor, *m_bgColor;
     BOOL m_changeTextColor;
 }
 - (instancetype)init;
-- (void)dealloc;
 @property (nonatomic, readonly) CGColorSpaceRef colorSpace CF_RETURNS_NOT_RETAINED;
 - (void)setTextColor:(UIColor*)textColor bgColor:(UIColor*)bgColor changeText:(BOOL)changeTextColor;
 - (void)setColor: (UIColor *)color;
@@ -38,9 +37,9 @@
 @property (nonatomic, getter=isTextColorMode, readonly) BOOL textColorMode;
 @property (nonatomic, readonly, copy) UIColor *textColor;
 @property (nonatomic, readonly, copy) UIColor *bgColor;
-@property (nonatomic, readonly) float hue;
-@property (nonatomic, readonly) float saturation;
-@property (nonatomic, readonly) float value;
+@property (nonatomic, readonly) CGFloat hue;
+@property (nonatomic, readonly) CGFloat saturation;
+@property (nonatomic, readonly) CGFloat value;
 @property (nonatomic, readonly, strong) HSVPicker *hsvPicker;
 @property (nonatomic, readonly, strong) HSVValuePicker *valuePicker;
 @property (nonatomic, readonly, strong) ColorTile *colorTile;

--- a/ui/ColorPicker.m
+++ b/ui/ColorPicker.m
@@ -54,7 +54,6 @@
 }
 - (instancetype) initWithFrame:(CGRect)frame withColorPicker: colorPicker;
 @property (nonatomic, readonly) unsigned int *hsvData;
-- (void)dealloc;
 - (void)drawRect:(CGRect)rect;
 - (void)mousePositionToColor:(CGPoint)point;
 - (void)touchesBegan:(NSSet*)touches withEvent:(UIEvent*)event;
@@ -594,6 +593,13 @@ void HSVtoRGB(CGFloat *r, CGFloat *g, CGFloat *b, CGFloat h, CGFloat s, CGFloat 
 @end
 
 @implementation ColorPicker
+@synthesize delegate = m_delegate;
+@synthesize hue = m_hue;
+@synthesize value = m_value;
+@synthesize saturation = m_saturation;
+@synthesize textColor = m_textColor;
+@synthesize bgColor = m_bgColor;
+
 - (instancetype)init {
     if ((self = [super init])!=nil) {
     	self.title = NSLocalizedString(@"Select Color", @"");
@@ -846,22 +852,6 @@ void HSVtoRGB(CGFloat *r, CGFloat *g, CGFloat *b, CGFloat h, CGFloat s, CGFloat 
 	[m_delegate colorPicker: self selectedColor: m_changeTextColor ? m_textColor : m_bgColor];
 }
 
--(float)hue {
-    return m_hue;
-}
--(float)saturation {
-    return m_saturation;
-}
--(float)value {
-    return m_value;
-}
--(UIColor *) textColor {
-    return m_textColor;
-}
--(UIColor *) bgColor {
-    return m_bgColor;
-}
-
 - (HSVPicker *)hsvPicker {
     return m_hsvPicker;
 }
@@ -872,11 +862,4 @@ void HSVtoRGB(CGFloat *r, CGFloat *g, CGFloat *b, CGFloat h, CGFloat s, CGFloat 
     return m_colorTile;
 }
 
-- (id<ColorPickerDelegate>)delegate {
-    return m_delegate;
-}
-
-- (void)setDelegate: (id<ColorPickerDelegate>)delegate {
-    m_delegate = delegate;
-}
 @end

--- a/ui/DisplayCell.h
+++ b/ui/DisplayCell.h
@@ -62,6 +62,8 @@ Copyright (C) 2008 Apple Inc. All Rights Reserved.
 
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 // cell identifier for this custom cell
 extern NSString *kDisplayCell_ID;
 
@@ -71,12 +73,12 @@ extern NSString *kDisplayCell_ID;
 	UIView	*view;
 }
 
-@property (nonatomic, strong) UIView *view;
+@property (nonatomic, strong, nullable) UIView *view;
 @property (nonatomic, strong) UILabel *nameLabel;
-
-- (void)setView:(UIView *)inView;
 
 @end
 
 #define kPageControlHeight              20.0
 #define kPageControlWidth               160.0
+
+NS_ASSUME_NONNULL_END

--- a/ui/FileBrowser.h
+++ b/ui/FileBrowser.h
@@ -20,18 +20,19 @@
 
 #import <UIKit/UIKit.h>
 
+@class FileBrowser;
 
 typedef NS_ENUM(unsigned int, FileBrowserState)  { kFBHidden, kFBShown, kFBDoShowRestore, kFBDoShowSave, kFBDoShowScript, kFBDoShowViewScripts, kFBDoShowRecord, kFBDoShowPlayback  };
 
-@protocol TextFileBrowser
+@protocol TextFileBrowser <NSObject>
 -(NSString*)textFileBrowserPath;
 @end
 
 
-@protocol FileSelected
+@protocol FileSelected <NSObject>
 @optional
--(void)fileBrowser:(id)browser fileSelected: (NSString*)filePath;
--(void)fileBrowser:(id)browser deleteFile: (NSString*)filePath;
+-(void)fileBrowser:(FileBrowser*)browser fileSelected: (NSString*)filePath;
+-(void)fileBrowser:(FileBrowser*)browser deleteFile: (NSString*)filePath;
 @end
 
 @interface FileBrowser : UIViewController <UITextFieldDelegate, UITableViewDataSource, UITableViewDelegate>
@@ -41,7 +42,7 @@ typedef NS_ENUM(unsigned int, FileBrowserState)  { kFBHidden, kFBShown, kFBDoSho
     NSMutableArray *m_files;
     NSString *m_path;
     NSUInteger m_rowCount;
-    id m_delegate;
+    id<FileSelected> __weak m_delegate;
     FileBrowserState m_dialogType;
     UIView *m_backgroundView;
     UITableView *m_tableView;
@@ -54,9 +55,6 @@ typedef NS_ENUM(unsigned int, FileBrowserState)  { kFBHidden, kFBShown, kFBDoSho
 @property (nonatomic, copy) NSString *path;
 - (void)reloadData;
 @property (nonatomic, weak) id<FileSelected> delegate;
-- (NSInteger) tableView:(UITableView*)tableView numberOfRowsInSection: (NSInteger)section;
-- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView;
-- (UITableViewCell*)tableView:(UITableView*)tableView cellForRowAtIndexPath:(NSIndexPath*)indexPath;
 @property (nonatomic, readonly, copy) NSString *selectedFile;
 - (void)commit:(id)sender;
 - (void)doneWithTextFile:(id)sender;

--- a/ui/FileBrowser.m
+++ b/ui/FileBrowser.m
@@ -53,7 +53,11 @@ static NSString *kSaveExt = @".sav", *kAltSaveExt = @".qut";
 @end
 
 
-@implementation FileBrowser 
+@implementation FileBrowser
+@synthesize delegate = m_delegate;
+@synthesize path = m_path;
+@synthesize textFileCount = m_textFileCount;
+
 - (instancetype)initWithDialogType:(FileBrowserState)dialogType {
     if ((self = [super init]) != nil) {
         m_tableViewController = [[UITableViewController alloc] init];
@@ -351,19 +355,6 @@ static NSString *kSaveExt = @".sav", *kAltSaveExt = @".qut";
         [m_delegate fileBrowser:self fileSelected: nil];
 }
 
--(void)setDelegate:(id<FileSelected>)delegate {
-    m_delegate = delegate;
-}
-
-- (id<FileSelected>)delegate {
-    return m_delegate;
-}
-
-
-- (NSString *)path {
-    return m_path;
-}
-
 - (void)setPath: (NSString *)path {
     if (m_path != path) {
         m_path = [path copy];
@@ -419,10 +410,6 @@ static NSString *kSaveExt = @".sav", *kAltSaveExt = @".qut";
     [m_files sortUsingSelector:@selector(compare:)];
     m_rowCount = [m_files count];
     [m_tableView reloadData];
-}
-
-- (int)textFileCount {
-    return m_textFileCount;
 }
 
 - (NSString*)tableView:(UITableView*)tableView titleForHeaderInSection:(NSInteger)section {

--- a/ui/FileTransferInfo.h
+++ b/ui/FileTransferInfo.h
@@ -20,6 +20,8 @@
 
 #define FTPPORT 2121
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface FileTransferInfo : FrotzCommonWebViewController {
     NSObject<FrotzSettingsStoryDelegate> *m_controller;
     UIWebView *m_webView;
@@ -37,8 +39,10 @@
 -(void)startServer;
 -(void)stopServer;
 @property (nonatomic, readonly) BOOL serverIsRunning;
-@property (nonatomic, readonly, copy) NSString *localIPAddress;
+@property (nonatomic, readonly, copy, nullable) NSString *localIPAddress;
 -(void)updateMessage;
 @end
 
 BOOL isHiddenFile(NSString *file);
+
+NS_ASSUME_NONNULL_END

--- a/ui/FileTransferInfo.m
+++ b/ui/FileTransferInfo.m
@@ -33,6 +33,7 @@ BOOL isHiddenFile(NSString *file) {
 
 
 @implementation FileTransferInfo
+@synthesize serverIsRunning = m_running;
 
 - (instancetype)initWithController:(NSObject<FrotzSettingsStoryDelegate>*)controller {
     if ((self = [super init])) {
@@ -277,10 +278,6 @@ BOOL isHiddenFile(NSString *file) {
         [self stopServer];
     else
         [self startServer];
-}
-
--(BOOL)serverIsRunning {
-    return m_running;
 }
 
 - (void)dealloc {

--- a/ui/FontPicker.h
+++ b/ui/FontPicker.h
@@ -8,12 +8,11 @@
 
 #import <UIKit/UIKit.h>
 
-@protocol FrotzFontDelegate
+@protocol FrotzFontDelegate <NSObject>
 -(void) setFont: (NSString*)font withSize:(NSInteger)size;
--(void) setFixedFont: (NSString*)font;
--(NSMutableString*) font;
--(NSMutableString*) fixedFont;
--(NSInteger) fontSize;
+@property (nonatomic, readonly, copy) NSString *font;
+@property (nonatomic, copy) NSString *fixedFont;
+@property (nonatomic, readonly) NSInteger fontSize;
 @end
 
 @interface FrotzFontInfo : NSObject {
@@ -31,10 +30,11 @@
 @interface FontPicker : UITableViewController {
     NSMutableArray *m_fonts;
     NSMutableArray *m_fixedFonts;
-    NSObject<FrotzFontDelegate> *m_delegate;
+    id<FrotzFontDelegate> __weak m_delegate;
     BOOL m_fixedFontsOnly;
 }
+@property (nonatomic, weak) id<FrotzFontDelegate> delegate;
+@property (nonatomic, assign) BOOL fixedFontsOnly;
+
 - (instancetype)init;
-- (void)setDelegate:(NSObject<FrotzFontDelegate>*)delegate;
-- (void)setFixedFontsOnly:(BOOL)fixed;
 @end

--- a/ui/FontPicker.m
+++ b/ui/FontPicker.m
@@ -25,6 +25,8 @@
 @end
 
 @implementation FontPicker
+@synthesize delegate = m_delegate;
+@synthesize fixedFontsOnly = m_fixedFontsOnly;
 
 static NSInteger sortFontsByFamilyName(id a, id b, void *context) {
     FrotzFontInfo *fa = (FrotzFontInfo*)a;
@@ -72,18 +74,6 @@ enum { kUIFontItalic=1, kUIFontBold=2 };
     }
     [m_fonts sortUsingFunction: sortFontsByFamilyName context: nil];
     [m_fixedFonts sortUsingFunction: sortFontsByFamilyName context: nil];
-}
-
-- (void)setFixedFontsOnly:(BOOL)fixed {
-    m_fixedFontsOnly = fixed;
-}
-
--(NSObject*)delegate {
-    return m_delegate;
-}
-
--(void)setDelegate:(NSObject<FrotzFontDelegate>*)delegate {
-    m_delegate = delegate;
 }
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {

--- a/ui/FrotzCommonWebView.h
+++ b/ui/FrotzCommonWebView.h
@@ -9,9 +9,8 @@
 
 #import <UIKit/UIKit.h>
 
-@interface FrotzCommonWebViewController : UIViewController {
-}
+@interface FrotzCommonWebViewController : UIViewController
 
-+(UIWebView*)sharedWebView;
++(nonnull UIWebView*)sharedWebView;
 +(void)releaseSharedWebView;
 @end

--- a/ui/FrotzDB.h
+++ b/ui/FrotzDB.h
@@ -11,7 +11,7 @@
 
     UITextField *m_textField;
     
-    id m_delegate;
+    id __weak m_delegate;
     BOOL m_hasAppeared;
     BOOL m_isUnlinking;
 }

--- a/ui/FrotzDB.m
+++ b/ui/FrotzDB.m
@@ -20,6 +20,7 @@
 #define kFontSizeStr "Font size (%d)"
 
 @implementation FrotzDBController
+@synthesize delegate = m_delegate;
 
 -(void)donePressed {
 
@@ -35,14 +36,6 @@
     {
     }
     return self;
-}
-
-- (void)setDelegate:(id)delegate {
-    m_delegate = delegate;
-}
-
-- (id)delegate {
-    return m_delegate;
 }
 
 -(void)viewDidUnload {

--- a/ui/FrotzInfo.h
+++ b/ui/FrotzInfo.h
@@ -10,9 +10,10 @@
 #import "FrotzSettings.h"
 //#import "ColorPicker.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
-@protocol KeyboardOwner
--(id)dismissKeyboard;
+@protocol KeyboardOwner <NSObject>
+-(nullable id)dismissKeyboard;
 @end
 
 @interface FrotzInfo : UIViewController <FrotzSettingsInfoDelegate> {
@@ -42,3 +43,5 @@
 -(void)updateAccessibility;
 -(void)updateTitle;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ui/FrotzInfo.m
+++ b/ui/FrotzInfo.m
@@ -12,6 +12,7 @@
 #import "TextViewExt.h"
 
 @implementation FrotzInfo
+@synthesize keyboardOwner = m_kbdOwner;
 
 -(instancetype)initWithSettingsController:(FrotzSettingsController*)settings navController:(UINavigationController*)navController navItem: (UINavigationItem*) navItem {
 	if ((self = [super init])) {
@@ -127,14 +128,6 @@
             [UIView commitAnimations];
         }
     }
-}
-
--(void)setKeyboardOwner:(id<KeyboardOwner>)kbdOwner {
-    m_kbdOwner = kbdOwner;
-}
-
--(id<KeyboardOwner>)keyboardOwner {
-    return m_kbdOwner;
 }
 
 -(void)frotzInfo {

--- a/ui/FrotzSettings.h
+++ b/ui/FrotzSettings.h
@@ -20,10 +20,8 @@
 -(UIColor*)backgroundColor;
 -(UIColor*)textColor;
 -(NSString*)rootPath;
--(BOOL)isCompletionEnabled;
--(void)setCompletionEnabled:(BOOL)on;
--(BOOL)canEditStoryInfo;
--(void)setCanEditStoryInfo: (BOOL)on;
+@property (nonatomic, getter=isCompletionEnabled) BOOL completionEnabled;
+@property (nonatomic) BOOL canEditStoryInfo;
 -(void)savePrefs;
 -(StoryBrowser*)storyBrowser;
 @end

--- a/ui/FrotzSettings.m
+++ b/ui/FrotzSettings.m
@@ -37,6 +37,9 @@
 #define kFontSizeStr "Font size (%d)"
 
 @implementation FrotzSettingsController
+@synthesize storyDelegate = m_storyDelegate;
+@synthesize infoDelegate = m_infoDelegate;
+@synthesize settingsActive = m_settingsShown;
 
 enum ControlTableSections
 {
@@ -133,22 +136,10 @@ enum ControlTableSections
     return self;
 }
 
-- (void)setInfoDelegate:(id<FrotzSettingsInfoDelegate>)delegate {
-    m_infoDelegate = delegate;
-}
-
-- (id<FrotzSettingsInfoDelegate>)infoDelegate {
-    return m_infoDelegate;
-}
-
 - (void)setStoryDelegate:(id<FrotzSettingsStoryDelegate,FrotzFontDelegate>)delegate {
     m_storyDelegate = delegate;
     [m_fontPicker setDelegate: m_storyDelegate];
     [m_frotzDB setDelegate: m_storyDelegate];
-}
-
-- (id<FrotzSettingsStoryDelegate, FrotzFontDelegate>)storyDelegate {
-    return m_storyDelegate;
 }
 
 - (NSString*)rootPath {
@@ -227,10 +218,6 @@ enum ControlTableSections
             [m_storyDelegate setFont: [m_storyDelegate font] withSize: value];
     }
     lastValue = value;
-}
-
-- (BOOL)settingsActive {
-    return m_settingsShown;
 }
 
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation {

--- a/ui/FrotzWordPicker.h
+++ b/ui/FrotzWordPicker.h
@@ -8,8 +8,6 @@
 #import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
 
-@interface FrotzWordPicker : UIView {
-
-}
+@interface FrotzWordPicker : UIView
 
 @end

--- a/ui/GettingStarted.h
+++ b/ui/GettingStarted.h
@@ -10,7 +10,6 @@
 #import "FrotzCommonWebView.h"
 
 
-@interface GettingStarted : FrotzCommonWebViewController {
-}
+@interface GettingStarted : FrotzCommonWebViewController
 - (instancetype)init NS_DESIGNATED_INITIALIZER;
 @end

--- a/ui/GlkView.h
+++ b/ui/GlkView.h
@@ -10,6 +10,7 @@
 #import "StoryMainViewController.h"
 #import "FrotzView.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface GlkView : FrotzView {
     NSTimer *m_tapTimer;
@@ -22,3 +23,4 @@
 @property (nonatomic, assign) BOOL tapInputEnabled;
 @end
 
+NS_ASSUME_NONNULL_END

--- a/ui/InputHelper.h
+++ b/ui/InputHelper.h
@@ -9,7 +9,7 @@
 #import <UIKit/UIKit.h>
 #import "FrotzWordPicker.h"
 
-@protocol FrotzInputDelegate
+@protocol FrotzInputDelegate <NSObject>
 -(void)inputHelperString:(NSString*)string;
 -(BOOL)isFirstResponder;
 @end
@@ -24,14 +24,14 @@ typedef NS_ENUM(unsigned int, FrotzInputHelperMode) {
 @interface FrotzInputHelper : UITableViewController {
     NSMutableArray *m_history;
     NSArray *m_commonCommands;
-    NSObject<FrotzInputDelegate> *m_delegate;
+    id<FrotzInputDelegate> __weak m_delegate;
     FrotzWordPicker *m_wordPicker;
     FrotzInputHelperMode m_mode;
     NSInteger m_lastCommonWordPicked;
     NSUInteger m_currHistoryItem;
 }
 - (instancetype)init;
-@property (nonatomic, weak) NSObject<FrotzInputDelegate> *delegate;
+@property (nonatomic, weak) id<FrotzInputDelegate> delegate;
 - (void)clearHistory;
 @property (nonatomic, readonly) NSUInteger historyCount;
 @property (nonatomic, readonly) NSUInteger menuCount;

--- a/ui/InputHelper.m
+++ b/ui/InputHelper.m
@@ -12,6 +12,7 @@
 const CGFloat kHistoryLineHeight = 20.0;
 
 @implementation FrotzInputHelper
+@synthesize delegate = m_delegate;
 
 - (instancetype)init {
     if ((self = [super initWithStyle:UITableViewStylePlain])) {
@@ -150,14 +151,6 @@ const CGFloat kHistoryLineHeight = 20.0;
         } else
             [self hideInputHelper];
     }
-}
-
--(NSObject<FrotzInputDelegate>*)delegate {
-    return m_delegate;
-}
-
--(void)setDelegate:(NSObject<FrotzInputDelegate>*)delegate {
-    m_delegate = delegate;
 }
 
 - (void)clearHistory {

--- a/ui/NotesViewController.h
+++ b/ui/NotesViewController.h
@@ -9,7 +9,7 @@
 #import <UIKit/UIKit.h>
 #import "FileBrowser.h"
 
-@protocol LockableKeyboard
+@protocol LockableKeyboard <NSObject>
 -(void)showKeyboardLockState;
 @end
 
@@ -23,11 +23,10 @@
     UIImageView *m_notesBGView;
     UIResponder *m_chainResponder;
     
-    UIViewController<TextFileBrowser,FileSelected, LockableKeyboard> *m_delegate;
+    UIViewController<TextFileBrowser,FileSelected, LockableKeyboard> __weak *m_delegate;
 }
 
--(NotesViewController*)initWithFrame:(CGRect)frame NS_DESIGNATED_INITIALIZER;
--(void)dealloc;
+-(instancetype)initWithFrame:(CGRect)frame NS_DESIGNATED_INITIALIZER;
 @property (nonatomic, copy) NSString *title;
 @property (nonatomic, copy) NSString *text;
 -(void)setFrame:(CGRect)frame;
@@ -48,7 +47,6 @@
 -(void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation;
 -(void)viewWillAppear:(BOOL)animated;
 -(void)viewWillDisappear:(BOOL)animated;
--(void)setDelegate:(UIViewController<TextFileBrowser,FileSelected,LockableKeyboard>*)delegate;
--(UIViewController<TextFileBrowser,FileSelected>*)delegate;
+@property (nonatomic, weak) UIViewController<TextFileBrowser,FileSelected,LockableKeyboard>* delegate;
 -(void)workaroundFirstResponderBug;
 @end

--- a/ui/NotesViewController.m
+++ b/ui/NotesViewController.m
@@ -26,10 +26,11 @@
 @end
 
 @implementation NotesViewController
+@synthesize delegate = m_delegate;
 
 - (NotesViewController*)initWithFrame:(CGRect)frame {
-    m_frame = frame;
     if ((self = [super init])) {
+        m_frame = frame;
         // Initialization code
     }
     return self;
@@ -148,14 +149,6 @@ static const int kNotesTitleHeight = 24;
     //    [m_notesView addSubview: scriptBrowseButton];
     
     [m_notesBGView addSubview: m_notesView];
-}
-
--(void)setDelegate:(UIViewController<TextFileBrowser,FileSelected,LockableKeyboard>*)delegate {
-    m_delegate = delegate;
-}
-
--(UIViewController<TextFileBrowser,FileSelected, LockableKeyboard>*)delegate {
-    return m_delegate;
 }
 
 -(void)notesAction:(id)sender {

--- a/ui/RichTextStyle.h
+++ b/ui/RichTextStyle.h
@@ -5,7 +5,25 @@
 //  Created by Craig Smith on 6/1/11.
 //  Copyright 2011 Craig Smith. All rights reserved.
 //
-typedef enum { kFTNormal=0, kFTBold=1, kFTItalic=2, kFTFixedWidth=4, kFTFontStyleMask=7, kFTReverse=8, kFTNoWrap=16,
-    kFTRightJust=32, kFTCentered=64, kFTImage=512, kFTInMargin=1024 } RichTextStyle;
+
+#include <CoreFoundation/CFBase.h>
+
+
+typedef CF_OPTIONS(unsigned int, RichTextStyle) { RichTextStyleNormal=0, RichTextStyleBold=1,
+    RichTextStyleItalic=2, RichTextStyleFixedWidth=4, RichTextStyleFontStyleMask=7,
+    RichTextStyleReverse=8, RichTextStyleNoWrap=16, RichTextStyleRightJustification=32,
+    RichTextStyleCentered=64, RichTextStyleImage=512, RichTextStyleInMargin=1024 };
 enum { kFTImageNumShift = 20 };
 
+#pragma mark compatibility macros
+#define kFTNormal RichTextStyleNormal
+#define kFTBold RichTextStyleBold
+#define kFTItalic RichTextStyleItalic
+#define kFTFixedWidth RichTextStyleFixedWidth
+#define kFTFontStyleMask RichTextStyleFontStyleMask
+#define kFTReverse RichTextStyleReverse
+#define kFTNoWrap RichTextStyleNoWrap
+#define kFTRightJust RichTextStyleRightJustification
+#define kFTCentered RichTextStyleCentered
+#define kFTImage RichTextStyleImage
+#define kFTInMargin RichTextStyleInMargin

--- a/ui/RichTextView.h
+++ b/ui/RichTextView.h
@@ -14,7 +14,7 @@
 @property(nonatomic, weak) RichTextView *textView;
 @end
 
-@protocol RTSelected
+@protocol RTSelected <NSObject>
 -(void)textSelected:(NSString*)text animDuration:(CGFloat)duration hilightView:(UIView <WordSelection>*)view;
 @end
 
@@ -80,7 +80,7 @@ typedef UIImage *(*RichDataGetImageCallback)(int imageNum);
     BOOL m_selectionDisabled;
     BOOL m_hyperlinkTest;
     
-    NSObject<RTSelected>* __weak m_selectionDelegate;
+    id<RTSelected> __weak m_selectionDelegate;
     
     BOOL m_freezeDisplay;
     CGRect m_delayedFrame;
@@ -105,7 +105,7 @@ typedef UIImage *(*RichDataGetImageCallback)(int imageNum);
 @property(nonatomic, assign) NSInteger lastAEIndexAccessed;
 //@property(nonatomic, assign) NSInteger selectedRun;
 //@property(nonatomic, assign) NSRange selectedColumnRange;
-@property(nonatomic, weak) NSObject<RTSelected>* selectionDelegate;
+@property(nonatomic, weak) id<RTSelected> selectionDelegate;
 @property(nonatomic, assign) BOOL selectionDisabled;
 @property(nonatomic, assign, getter=displayFrozen) BOOL freezeDisplay;
 @property(nonatomic, assign) RichDataGetImageCallback richDataGetImageCallback;
@@ -144,7 +144,6 @@ typedef UIImage *(*RichDataGetImageCallback)(int imageNum);
 - (void)reflowText;
 - (void)repositionAfterReflow;
 - (void)reloadImages;
-- (void)dealloc;
 @property (nonatomic, weak) UIViewController<UIScrollViewDelegate> *delegate;
 @property (nonatomic, copy) UIFont *font;
 @property (nonatomic, copy) UIFont *fixedFont;

--- a/ui/StoryBrowser.h
+++ b/ui/StoryBrowser.h
@@ -27,6 +27,8 @@
 @class StoryDetailsController;
 @class StoryBrowser;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface StoryInfo : NSObject {
     NSString *path;
 }
@@ -35,10 +37,10 @@
 @property (nonatomic, readonly, copy) NSString *title;
 
 @property(nonatomic,copy) NSString *path;
-@property(nonatomic,weak) StoryBrowser *browser;
+@property(nonatomic,weak,nullable) StoryBrowser *browser;
 @end
 
-@interface StoryBrowser : UITableViewController <UIActionSheetDelegate, UISplitViewControllerDelegate, UIPopoverControllerDelegate,UISearchBarDelegate, UISearchDisplayDelegate> {
+@interface StoryBrowser : UITableViewController <UIActionSheetDelegate, UISplitViewControllerDelegate, UIPopoverControllerDelegate,UISearchBarDelegate, UISearchDisplayDelegate, UITableViewDataSource, UITableViewDelegate> {
     NSMutableArray *m_paths;
 
     int m_numStories;
@@ -80,10 +82,10 @@
 - (instancetype)init;
 @property (nonatomic, copy) NSString *launchPath;
 @property (nonatomic, readonly, strong) UIView *navTitleView;
-@property (nonatomic, readonly, copy) NSMutableArray *storyNames;
+@property (nonatomic, readonly, copy) NSArray *storyNames;
 - (BOOL)storyIsInstalled:(NSString*)story;
-- (NSString*)canonicalStoryName:(NSString*)story;
-@property (nonatomic, readonly, copy) NSMutableArray *unsupportedStoryNames;
+- (nullable NSString*)canonicalStoryName:(NSString*)story;
+@property (nonatomic, readonly, copy) NSArray *unsupportedStoryNames;
 - (void)addRecentStoryInfo:(StoryInfo*)storyInfo;
 - (void)addRecentStory:(NSString*)storyInfo;
 - (void)addPath: (NSString *)path;
@@ -91,7 +93,7 @@
 - (void)refresh;
 - (void)reloadData;
 - (void)updateNavButton;
-@property (nonatomic, readonly, strong) UIBarButtonItem *nowPlayingNavItem;
+@property (nonatomic, readonly, strong, nullable) UIBarButtonItem *nowPlayingNavItem;
 @property (nonatomic, readonly, strong) StoryMainViewController *storyMainViewController;
 @property (nonatomic, readonly, strong) FrotzInfo *frotzInfoController;
 @property (nonatomic, readonly, strong) FrotzSettingsController *settings;
@@ -109,7 +111,7 @@
 - (void)addDescript: (NSString*)descript forStory:(NSString*)story;
 @property (nonatomic, readonly) BOOL canEditStoryInfo;
 - (NSString*)fullTitleForStory:(NSString*)story;
-- (NSString*)customTitleForStory:(NSString*)story storyKey:(NSString**)storyKey;
+- (nullable NSString*)customTitleForStory:(NSString*)story storyKey:(NSString*__nonnull*__nullable)storyKey;
 - (NSString*)tuidForStory:(NSString*)story;
 - (NSString*)authorsForStory:(NSString*)story;
 - (NSString*)descriptForStory:(NSString*)story;
@@ -125,7 +127,7 @@
 - (void)hideStory: (NSString*)story withState:(BOOL)hide;
 - (void)unHideAll;
 - (BOOL)isHidden: (NSString*)story;
-- (NSString*)getNotesForStory:(NSString*)story;
+- (nullable NSString*)getNotesForStory:(NSString*)story;
 - (void)saveNotes:(NSString*)notesText forStory:(NSString*)story;
 - (void)saveRecents;
 - (void)saveStoryInfoDict;
@@ -138,20 +140,16 @@
 @property (nonatomic, readonly, copy) NSString *currentStory;
 - (void)launchBrowserWithURL:(NSString*)url;
 - (void)launchBrowser;
-- (NSInteger)numberOfSectionsInTableView: (UITableView*)tableView;
 - (NSUInteger)indexRowFromStoryInfo:(StoryInfo*)recentStory;
 - (NSUInteger)recentRowFromStoryInfo:(StoryInfo*)storyInfo;
-- (NSString*)tableView:(UITableView*)tableView titleForHeaderInSection:(NSInteger)section;
-- (NSInteger)tableView:(UITableView*)tableView numberOfRowsInSection:(NSInteger)section;
-- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath;
 - (UITableViewCell*)tableView:(UITableView*)tableView cellForRowAtIndexPath:(NSIndexPath*)indexPath;
-- (StoryInfo *)storyInfoForIndexPath:(NSIndexPath*)indexPath tableView:(UITableView*)tableView;
+- (nullable StoryInfo *)storyInfoForIndexPath:(NSIndexPath*)indexPath tableView:(UITableView*)tableView;
 - (NSString *)storyForIndexPath:(NSIndexPath*)indexPath tableView:(UITableView*)tableView;
 - (void)storyInfoChanged;
 - (void)updateAccessibility;
 
-@property(nonatomic,strong) UIPopoverController *popoverController;
-@property(nonatomic,strong) UIBarButtonItem *popoverBarButton;
+@property(nonatomic,strong,nullable) UIPopoverController *popoverController;
+@property(nonatomic,strong,nullable) UIBarButtonItem *popoverBarButton;
 @property(nonatomic,strong) UISearchDisplayController *searchDisplayController;
 @end
 
@@ -160,3 +158,5 @@ extern NSString *storyGamePath;
 @interface NSString (storyKey)
 @property (nonatomic, readonly, copy) NSString *storyKey;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ui/StoryBrowser.m
+++ b/ui/StoryBrowser.m
@@ -577,10 +577,10 @@ static NSInteger sortPathsByFilename(id a, id b, void *context) {
     return [str1 caseInsensitiveCompare: str2];
 }
 
-- (NSMutableArray*)storyNames {
+- (NSArray*)storyNames {
     if (!m_numStories)
         [self refresh];
-    return m_storyNames;
+    return [m_storyNames copy];
 }
 
 -(BOOL)storyIsInstalled:(NSString*)story {
@@ -598,8 +598,8 @@ static NSInteger sortPathsByFilename(id a, id b, void *context) {
     return nil;
 }
 
-- (NSMutableArray*)unsupportedStoryNames {
-    return m_unsupportedNames;
+- (NSArray*)unsupportedStoryNames {
+    return [m_unsupportedNames copy];
 }
 
 -(void)refresh {

--- a/ui/StoryMainViewController.h
+++ b/ui/StoryMainViewController.h
@@ -39,7 +39,7 @@ void iosif_clear_input(NSString *initStr);
 void iosif_feed_input(NSString *str);
 void iosif_feed_input_line(NSString *str);
 
-@protocol InputHelperDelegate
+@protocol InputHelperDelegate <NSObject>
 -(void)hideInputHelper;
 -(BOOL)inputHelperShown;
 -(UIView*) inputHelperView;
@@ -71,7 +71,7 @@ extern StoryBrowser *theStoryBrowser;
     FrotzInfo *m_frotzInfoController;
    
     NSMutableString *m_currentStory;    
-    NSMutableString *m_fontname;
+    NSString *m_fontname;
     NSInteger m_fontSize;
     CGFloat topWinSize;
     

--- a/ui/StoryMainViewController.m
+++ b/ui/StoryMainViewController.m
@@ -148,10 +148,10 @@ void iosif_ioinit() {
         pthread_mutex_init(&inputMutex, NULL);
         pthread_cond_init(&winSizeChangedCond, NULL);
         winSizeChanged = 0;
-        ipzBufferStr = [[NSMutableString alloc] initWithBytes:nil length:0 encoding:NSISOLatin1StringEncoding];
-        ipzStatusStr = [[NSMutableString alloc] initWithBytes:nil length:0 encoding:NSISOLatin1StringEncoding];
-        ipzInputBufferStr = [[NSMutableString alloc] initWithBytes:nil length:0 encoding:NSISOLatin1StringEncoding];
-        ipzLineInputStr = [[NSMutableString alloc] initWithBytes:nil length:0 encoding:NSISOLatin1StringEncoding];
+        ipzBufferStr = [[NSMutableString alloc] init];
+        ipzStatusStr = [[NSMutableString alloc] init];
+        ipzInputBufferStr = [[NSMutableString alloc] init];
+        ipzLineInputStr = [[NSMutableString alloc] init];
         didInitIO = YES;
     }
 }
@@ -199,7 +199,7 @@ static NSMutableString *getBufferStrForWin(int winNum, BOOL *isStatus) {
             if ([glkInputs count] == 0)
                 [glkInputs addObject: ipzBufferStr];
             else
-                [glkInputs addObject: [[NSMutableString alloc] initWithBytes:nil length:0 encoding:NSISOLatin1StringEncoding]];
+                [glkInputs addObject: [[NSMutableString alloc] init]];
         }
         bufferStr = glkInputs[winNum];
     } else {
@@ -1073,6 +1073,10 @@ static void setColorTable(RichTextView *v) {
 
 
 @implementation StoryMainViewController 
+@synthesize font = m_fontname;
+@synthesize fontSize = m_fontSize;
+@synthesize completionEnabled = m_completionEnabled;
+@synthesize canEditStoryInfo = m_canEditStoryInfo;
 
 - (StoryMainViewController*)init {
     self = [super init];
@@ -1100,10 +1104,10 @@ static void setColorTable(RichTextView *v) {
         
         
         if (![fileMgr fileExistsAtPath: storyGamePath]) {
-            [fileMgr createDirectoryAtPath: storyGamePath attributes: nil];
+            [fileMgr createDirectoryAtPath: storyGamePath attributes: @{}];
         }
         if (![fileMgr fileExistsAtPath: storyTopSavePath]) {
-            [fileMgr createDirectoryAtPath: storyTopSavePath attributes: nil];
+            [fileMgr createDirectoryAtPath: storyTopSavePath attributes: @{}];
         }
         
         NSString *resourcePath = [[NSBundle mainBundle] resourcePath];
@@ -2675,10 +2679,6 @@ static UIImage *GlkGetImageCallback(int imageNum) {
     [m_inputLine setFont: font];
 }
 
--(NSString*) font {
-    return m_fontname;
-}
-
 -(void) setFixedFont: (NSString*)font {
     NSInteger fixedFontSize = gLargeScreenDevice ? m_fontSize : (m_fontSize > 12 ? (m_fontSize+5)/2:8);
     [m_storyView setFixedFont: [UIFont fontWithName: font size: fixedFontSize]];
@@ -2686,10 +2686,6 @@ static UIImage *GlkGetImageCallback(int imageNum) {
 
 -(NSString*) fixedFont {
     return [[m_storyView fixedFont] fontName];
-}
-
--(NSInteger) fontSize {
-    return m_fontSize;
 }
 
 -(StoryView*) storyView {
@@ -2767,7 +2763,7 @@ static UIImage *GlkGetImageCallback(int imageNum) {
     if (m_currentStory) {
         storySavePath = [storyTopSavePath stringByAppendingPathComponent: [self saveSubFolderForStory: m_currentStory]];
         if (![fileMgr fileExistsAtPath: storySavePath])
-            [fileMgr createDirectoryAtPath: storySavePath attributes: nil];
+            [fileMgr createDirectoryAtPath: storySavePath attributes: @{}];
     	strcpy(SAVE_PATH, [storySavePath UTF8String]);
         
         if (![fileMgr fileExistsAtPath: storySIPPathOld]) {
@@ -4346,22 +4342,6 @@ static void setScreenDims(char *storyNameBuf) {
     }
 #endif
     
-}
-
--(BOOL)isCompletionEnabled {
-    return m_completionEnabled;
-}
-
--(void)setCompletionEnabled:(BOOL)on {
-    m_completionEnabled = on;
-}
-
--(BOOL)canEditStoryInfo {
-    return m_canEditStoryInfo;
-}
-
--(void)setCanEditStoryInfo: (BOOL)on {
-    m_canEditStoryInfo = on;
 }
 
 -(StoryInputLine*)inputLine {

--- a/ui/StoryView.h
+++ b/ui/StoryView.h
@@ -10,6 +10,7 @@
 #import "StoryMainViewController.h"
 #import "FrotzView.h"
 
+NS_ASSUME_NONNULL_BEGIN
 
 @interface StoryView : FrotzView {
     BOOL m_isMagnifying;
@@ -20,7 +21,8 @@
 - (void)appendText:(NSString*)text;
 - (BOOL)handleTouch: (UITouch*)touch withEvent: (UIEvent*)event;
 - (void)skipNextTap;
-- (NSString*)lookForTruncatedWord:(NSString*)word;
+- (nullable NSString*)lookForTruncatedWord:(NSString*)word;
 @property (nonatomic, assign) BOOL tapInputEnabled;
 @end
 
+NS_ASSUME_NONNULL_END

--- a/ui/StoryView.m
+++ b/ui/StoryView.m
@@ -6,6 +6,7 @@
 #import "FrotzAppDelegate.h"
 #import "FileBrowser.h"
 #import "ui_utils.h"
+#include <execinfo.h>
 
 #include <stdlib.h>
 @implementation StoryView
@@ -198,8 +199,6 @@
     
 }
 
-
-#include <execinfo.h>
 
 -(void)setFrame:(CGRect)frame {
 

--- a/ui/UIFontExt.h
+++ b/ui/UIFontExt.h
@@ -12,7 +12,7 @@
 // app store.  The font trait method lamely just looks for substrings in the font name to
 // identify bold, italic, etc. and returns those bits, so if Apple ever makes this
 // method available again, I can switch back to using it with no effort.
-enum { 
+typedef NS_OPTIONS(unsigned int, UIFontTraits) {
     UINormalFontMask = 0,
     UIItalicFontMask = 0x00000001, 
     UIBoldFontMask = 0x00000002, 
@@ -30,5 +30,5 @@ enum {
 
 
 @interface UIFont (FontExt) 
--(int)fontTraits;
+-(UIFontTraits)fontTraits;
 @end

--- a/ui/UIFontExt.m
+++ b/ui/UIFontExt.m
@@ -10,7 +10,7 @@
 
 
 @implementation UIFont (FontExt)
--(int)fontTraits {
+-(UIFontTraits)fontTraits {
     NSString *name = [self fontName];
     int traits = UINormalFontMask;
     if ([name rangeOfString:@"bold" options: NSCaseInsensitiveSearch].length > 0)

--- a/ui/URLPromptController.h
+++ b/ui/URLPromptController.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@protocol URLPromptDelegate
+@protocol URLPromptDelegate <NSObject>
 -(void)promptURL;
 -(void)enterURL:(NSString*)url;
 -(void)dismissURLPrompt;
@@ -18,7 +18,7 @@
 @interface URLPromptController : UIViewController <UISearchBarDelegate>
 {
     UISearchBar	*m_textbar;
-    id<URLPromptDelegate> m_delegate;
+    id<URLPromptDelegate> __weak m_delegate;
 }
 -(void)setText:(NSString*)text;
 -(void)setPlaceholder:(NSString*)text;

--- a/ui/URLPromptController.m
+++ b/ui/URLPromptController.m
@@ -10,6 +10,7 @@
 #include "iosfrotz.h"
 
 @implementation URLPromptController
+@synthesize delegate = m_delegate;
 
 - (instancetype)init
 {
@@ -20,14 +21,6 @@
     }
     
     return self;
-}
-
--(void)setDelegate:(id<URLPromptDelegate>)del {
-    m_delegate = del;
-}
-
--(id<URLPromptDelegate>)delegate {
-    return m_delegate;
 }
 
 

--- a/ui/WordSelectionProtocol.h
+++ b/ui/WordSelectionProtocol.h
@@ -7,8 +7,10 @@
  *
  */
 
+#import <UIKit/UIFont.h>
+#import <UIKit/UILabel.h>
 
-@protocol WordSelection
+@protocol WordSelection <NSObject>
 -(void)setFont:(UIFont*)font;
 @end
 


### PR DESCRIPTION
* Mark many iVars that are delegates as __weak, to prevent memory leaks.
* Mark all protocols as implementing the NSObject protocol.
* Add nullability info to some classes.
* Synthesize some properties, and remove plain getters/setters in the same (But mainly delegates).
* Remove braces on interfaces that don't declare iVars.
* Remove dealloc declarations in interfaces.